### PR TITLE
Update links on pages for videos 1 and 2

### DIFF
--- a/src/v1/video-reel/01-up-and-running.md
+++ b/src/v1/video-reel/01-up-and-running.md
@@ -12,4 +12,4 @@ order: 100
 * [Installing Node, Redis and PostgreSQL on your Mac](/v1/guides/install-node-redis-and-postgres-on-your-mac.html)
 * [Six Degrees Wireframes](https://github.com/alarner/perk-six-degrees/blob/master/Wireframes.pdf)
 * [Code (GitHub)](https://github.com/alarner/perk-six-degrees/tree/01)
-* [Video Transcript](https://github.com/alarner/perk-reel/blob/master/six-degrees/02%20-%20Modify%20the%20Homepage%20View/transcript.md)
+* [Video Transcript](https://github.com/alarner/perk-reel/blob/master/six-degrees/01%20-%20Up%20and%20Running/transcript.md)

--- a/src/v1/video-reel/02-modifying-the-homepage-view.md
+++ b/src/v1/video-reel/02-modifying-the-homepage-view.md
@@ -10,8 +10,8 @@ order: 200
 ## Resources
 
 * [npmjs.com](https://www.npmjs.com/)
-* [Code (GitHub)](/v1/api/views.html#changing-templating-engines)
+* [Changing Templating Engines](/v1/api/views.html#changing-templating-engines)
 * [Configuration Docs](/v1/api/config.html)
 * [Code (GitHub)](https://github.com/alarner/perk-six-degrees/commit/25b5dde72ac335c9c4a7454d66d30ea18a8043fd)
-* [Video Transcript]()
+* [Video Transcript](https://github.com/alarner/perk-reel/blob/master/six-degrees/02%20-%20Modify%20the%20Homepage%20View/transcript.md)
 


### PR DESCRIPTION
Upon viewing the video tutorials, I noticed that some of the links needed a bit of TLC.

I created **[this issue](https://github.com/alarner/perk/issues/93)** and then **[this issue](https://github.com/alarner/perk/issues/94)**, too.

Here are the repaired links! 🤓 