### PR TITLE
Add alternative brew commands

### DIFF
--- a/src/v1/guides/install-node-redis-and-postgres-on-your-mac.md
+++ b/src/v1/guides/install-node-redis-and-postgres-on-your-mac.md
@@ -9,15 +9,29 @@ order: 020
 
 > If you already have these installed, you can skip this step.
 
-Once you have [homebrew installed](/v1/guides/installing-homebrew-on-your-mac.html) you can install node and redis very easily. If you're planning on building a database driven app you will want to install a database as well. We recommend Postgres. To install these three just type the following command into your terminal:
+Once you have [homebrew installed](/v1/guides/installing-homebrew-on-your-mac.html), you can install node and redis very easily. If you're planning on building a database-driven app, you will want to install a database, as well. We recommend Postgres. To install these three just type the following command into your terminal:
 
 `brew install node redis postgres`
 
-> postgres is optional and you can leave it out.
+> postgres is optional, and you can leave it out.
 
-If you don't want to have to manually start the redis and postgres servers each time your computer restarts you should be sure to run the commands that start with `launchctl load ...`. They will be displayed in your terminal after brew is finished installing and will probably look like this:
+If you don't want to have to manually start the redis and postgres servers each time your computer restarts, be sure to run the commands that start with `launchctl load ...`. They will be displayed in your terminal after brew is finished installing and will probably look like this:
 
 ```
 launchctl load ~/Library/LaunchAgents/homebrew.mxcl.postgresql.plist
 launchctl load ~/Library/LaunchAgents/homebrew.mxcl.redis.plist
+```
+
+If the commands above are not working, then brew on your machine might be a little out of sync. No worries, just run these commands:
+
+```
+brew info postgres
+brew info redis
+```
+
+Near the bottom of these info pages you will find the correct command to run on your machine. The correct commands may look something like this:
+
+```
+brew services start postgresql
+brew servcies start redis
 ```


### PR DESCRIPTION
When I was installing the necessary packages via brew, I used the old trusty advice found on **[this page](http://perkframework.com/v1/guides/install-node-redis-and-postgres-on-your-mac.html)**. 

I attempted to start postgres and redis up, but the commands just fizzled. ✨ 
Ever a good lad, I [opened an issue](https://github.com/alarner/perk/issues/91).

Dear Prof. @alarner gently guided me to these alternative commands which are now found in this PR.

```
brew info postgres
brew info redis
```

I humbly submit these mine edits. My hope is that the next traveller with brew packages strewn across a hard drive will also find solace in installing PerkFramework with these handy commands.

